### PR TITLE
やることリストの遷移先作成

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,6 +15,9 @@ import Edit_AddScreen from './screens/edit_add.js';
 import Edit_ChangeScreen from './screens/edit_change.js';
 import Edit_DeleteScreen from './screens/edit_delete.js';
 
+import YesScreen from './screens/yes.js';
+import YaranaiScreen from './screens/yaranai.js';
+import OKScreen from './screens/ok.js';
 const Stack = createStackNavigator();
 
 
@@ -55,36 +58,46 @@ export default function App() {
           options={{ title: 'やることの編集' }}
         />
         <Stack.Screen
-
-          name="Today_Detail"
+          name="今日の詳細"
           component={Today_DetailScreen}
           options={{ title: '今日の詳細' }} // 任意のタイトルを設定
         />
         <Stack.Screen
-
-        
-       　 name="やることを追加"
-        　component={Edit_AddScreen}
-       　 options={{ title: 'やることを追加' }} // 任意のタイトルを設定
+          name="やることを追加"
+          component={Edit_AddScreen}
+          options={{ title: 'やることを追加' }} // 任意のタイトルを設定
         />
         <Stack.Screen
-        
-        　name="やることを変更"
-        　component={Edit_ChangeScreen}
-        　options={{ title: 'やることを変更' }} // 任意のタイトルを設定
+          name="やることを変更"
+          component={Edit_ChangeScreen}
+          options={{ title: 'やることを変更' }} // 任意のタイトルを設定
         />
         <Stack.Screen
-         
-         　name="やることを消去"
-         　component={Edit_DeleteScreen}
-         　options={{ title: 'やることを消去' }} // 任意のタイトルを設定
+          name="やることを消去"
+          component={Edit_DeleteScreen}
+          options={{ title: 'やることを消去' }} // 任意のタイトルを設定
         />
         <Stack.Screen
-
           name="OtherdayScreen"
           component={OtherdayScreen}
           options={{ title: '今日以外のやること画面' }}
         />
+        <Stack.Screen
+          name="はい"
+          component={YesScreen}
+          options={{ title: 'はい' }} // 任意のタイトルを設定
+        />
+        <Stack.Screen
+          name="今日はやらない"
+          component={YaranaiScreen}
+          options={{ title: '今日はやらない' }} // 任意のタイトルを設定
+        />
+        <Stack.Screen
+          name="完了画面"
+          component={OKScreen}
+          options={{ title: '完了画面' }} // 任意のタイトルを設定
+        />
+        
 
       </Stack.Navigator>
     </NavigationContainer>

--- a/screens/ok.js
+++ b/screens/ok.js
@@ -1,0 +1,32 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
+import * as React from 'react';
+
+export default function OKScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'pink',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    marginTop: 20,
+    backgroundColor: 'white',
+    padding: 50,
+    borderRadius: 10,
+    width: 350,
+  },
+  buttonText: {
+    color: 'black',
+    fontSize: 32,
+    fontWeight: 'bold',
+  },
+});

--- a/screens/today.js
+++ b/screens/today.js
@@ -35,7 +35,6 @@ export default function TodayScreen() {
 
       // 重複を排除するために Set を使用
       const postDataSet = new Set();
-
       const data = [];
 
         querySnapshot.forEach((doc) => {
@@ -70,8 +69,25 @@ export default function TodayScreen() {
 
   // タスクをタップしたときの処理
   const handleTaskPress = (post) => {
-    // ここでタスクIDを元に遷移先の画面に遷移する処理を追加
-    navigation.navigate('今日の詳細', { id: post.id, yarukoto: post.yarukoto });
+    if (post.who) {
+      navigation.navigate('完了画面', { 
+        id: post.id, 
+        yarukoto: post.yarukoto,
+        year: year,
+        month: month,
+        day: day,
+        dayOfWeek: dayOfWeek,
+        });
+    } else {
+      navigation.navigate('今日の詳細', { 
+        id: post.id, 
+        yarukoto: post.yarukoto,
+        year: year,
+        month: month,
+        day: day,
+        dayOfWeek: dayOfWeek,
+      });
+    }
   };
 
   return (
@@ -84,16 +100,22 @@ export default function TodayScreen() {
           </Text>
         </Text>
       </View>
-      <TouchableOpacity
+      {posts.map((post)=>(
+        <TouchableOpacity
+        key={post.id}
         style={[styles.button, { fontSize: 20, textAlign: 'center'}]}
-        onPress={() => navigation.navigate('今日の詳細')}
+        onPress={() => handleTaskPress(post)}
       >
-        {posts.map((post)=>(
-          <Text key={post.id} style={[styles.largeText, { fontSize: 30, textAlign: 'center'}]} onPress={() => handleTaskPress(post)}>
+          <Text key={post.id} style={[styles.largeText, { fontSize: 30, textAlign: 'center'}]}>
             {post.yarukoto}
         </Text>
-      ))}
+        {post.who ? (
+            <View style={styles.square}></View>
+          ) : (
+            <View style={styles.square2}></View>
+          )}
       </TouchableOpacity>
+      ))}
     </View>
   );
 }
@@ -142,5 +164,25 @@ const styles = StyleSheet.create({
     padding: 5,
     borderRadius: 10,
     marginVertical: 10,
+  },
+  square: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'red', // 四角形の背景色
+    position: 'absolute',
+    right: 0,
+    right:10, // 左に寄せる
+    top: '50%',
+    marginTop: 10, // 上部のマージンを調整してセンタリング
+  },
+  square2: {
+    width: 50,
+    height: 50,
+    borderWidth: 3, // 縁の太さ
+    borderColor: 'black', // 縁の色
+    position: 'absolute',
+    right:10, // 左に寄せる
+    top: '50%',
+    marginTop: 10, // 上部のマージンを調整してセンタリング
   },
 });

--- a/screens/today_detail.js
+++ b/screens/today_detail.js
@@ -5,21 +5,43 @@ import { useNavigation } from '@react-navigation/native';
 export default function Today_DetailScreen({ route }) {
   const navigation = useNavigation();
   // const { taskId } = route.params;// タスクIDを取得
-  const {id, yarukoto} = route.params; // タスク名を取得
+  const {id, yarukoto, year, month, day, dayOfWeek} = route.params; // タスク名を取得
+  
+
+  // はいのボタンをタップした際の処理を記述
+  const handleYesPress = () => {
+    navigation.navigate('はい', {
+      id: id, 
+      yarukoto: yarukoto,
+      year: year,
+      month: month,
+      day: day,
+      dayOfWeek: dayOfWeek,
+    });
+  };
+  // 今日はやらないボタンをタップした際の処理を記述
+  const handleYaranaiPress = () => {
+    navigation.navigate('今日はやらない');
+  };
 
   return (
     <View style={styles.container}>
+      <Text style={[styles.headerText, { fontSize: 40 , textAlign: 'center' }]}>
+      {`${month}月${day}日${dayOfWeek}の\nやること`}
+      </Text>
+      <View style={styles.taskDetailContainer}>
       <Text style={styles.taskDetail}>{yarukoto}</Text>
+      </View>
       <Text style={styles.questionText}>できましたか</Text>
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
-          <Text>はい</Text>
+        <TouchableOpacity style={styles.button} onPress={handleYesPress}>
+          <Text style={styles.buttonText}>はい</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
-          <Text>いいえ</Text>
+          <Text style={styles.buttonText}>いいえ</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
-          <Text>今日はやらない</Text>
+        <TouchableOpacity style={styles.button} onPress={handleYaranaiPress}>
+          <Text style={styles.buttonText}>今日はやらない</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -34,21 +56,41 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   taskDetail: {
-    fontSize: 24,
+    fontSize: 50,
     marginBottom: 20,
   },
   questionText: {
-    fontSize: 20,
+    fontSize: 40,
     marginBottom: 10,
   },
   buttonContainer: {
-    flexDirection: 'row',
+    flexDirection: 'column',
+    marginBottom: 10,
   },
   button: {
+    marginTop: 20,
+    padding: 50,
+    borderRadius: 10,
+    width: 250,
     backgroundColor: 'pink',
-    paddingHorizontal: 20,
-    paddingVertical: 10,
+    paddingHorizontal: 30,
+    paddingVertical: 20,
     marginHorizontal: 10,
     borderRadius: 5,
+  },
+  buttonText: {
+    fontSize: 24, // フォントサイズを大きくする
+    textAlign: 'center', // 中央揃えにする
+  },
+  taskDetailContainer: {
+    backgroundColor: 'white',
+    borderRadius: 10,
+    padding: 20,
+    width: 400,
+    marginBottom: 25,
+  },
+  taskDetail: {
+    fontSize: 50,
+    textAlign: 'center',
   },
 });

--- a/screens/yaranai.js
+++ b/screens/yaranai.js
@@ -1,0 +1,32 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
+import * as React from 'react';
+
+export default function YaranaiScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'pink',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    marginTop: 20,
+    backgroundColor: 'white',
+    padding: 50,
+    borderRadius: 10,
+    width: 350,
+  },
+  buttonText: {
+    color: 'black',
+    fontSize: 32,
+    fontWeight: 'bold',
+  },
+});

--- a/screens/yes.js
+++ b/screens/yes.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function YesScreen({ route }) {
+  // Today_DetailScreen から渡されたパラメータを取得
+  const { month, day, dayOfWeek, yarukoto, who } = route.params;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.headerText}>{`${month}月${day}日${dayOfWeek}のやること`}</Text>
+      <Text style={styles.detailText}>{`${yarukoto}`}</Text>
+      <Text style={styles.footerText}>{`誰がしましたか: ${who}`}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#bba8e3',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  detailText: {
+    fontSize: 20,
+    marginBottom: 10,
+  },
+  footerText: {
+    fontSize: 18,
+  },
+});


### PR DESCRIPTION
### 遷移先の画面に受け渡す値を設定する。
today.jsより
```
// タスクをタップしたときの処理
  const handleTaskPress = (post) => {
    if (post.who) {
      navigation.navigate('完了画面', { 
        id: post.id, 
        yarukoto: post.yarukoto,
        year: year,
        month: month,
        day: day,
        dayOfWeek: dayOfWeek,
        });
    } else {
      navigation.navigate('今日の詳細', { 
        id: post.id, 
        yarukoto: post.yarukoto,
        year: year,
        month: month,
        day: day,
        dayOfWeek: dayOfWeek,
      });
    }
  };
```
year, month, day, dayOfWeekそれぞれに、先に定義した今日の日付を入れているが、この部分をカレンダーから取得してきた日付の値に変えれば使えると思う。
これにより、遷移先の画面でデータを引き継いで使えるようになる。

### 条件文による遷移先の指定
また、if文のようにして遷移先を分ける
today.jsより
```
{post.who ? (
            <View style={styles.square}></View>
          ) : (
            <View style={styles.square2}></View>
          )}
```
これは、firebaseのカラムwhoが空かどうかを判別している。
空の場合は詳細画面へ、空ではない場合は完了画面へと遷移する。
